### PR TITLE
 Fix No suitable driver found for jdbc:sybase

### DIFF
--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -218,7 +218,7 @@ def _jdbc_connect_jpype(jclassname, url, driver_args, jars, libs):
         def _java_array_byte(data):
             return jpype.JArray(jpype.JByte, 1)(data)
     # register driver for DriverManager
-    jpype.JClass(jclassname)
+    jpype.JClass(jclassname)()
     if isinstance(driver_args, dict):
         Properties = jpype.java.util.Properties
         info = Properties()


### PR DESCRIPTION
I had to make this change to avoid No suitable driver found for jdbc:sybase.

Think after early versions of Java it looks like this is necessary